### PR TITLE
Re-ordering projects

### DIFF
--- a/_includes/tf_projects.html
+++ b/_includes/tf_projects.html
@@ -1,6 +1,7 @@
 <div class="col col-12">
     <div class="row justify-content-center">
-        {% for project in site.projects %}
+        {% assign sorted_projects = site.projects | sort: 'sort_key' %}
+        {% for project in sorted_projects %}
             {% if project.icons %}
                 <div class="col col-6 col-sm-6 col-md-4 col-lg-3 col-xl-2">
                     <a href="{{project.url}}">

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -96,7 +96,8 @@ layout: base
                                 </div>
                                 <div class="col col-12">
                                     <div class="row other_projects">
-                                        {% for project in site.projects %}
+                                        {% assign sorted_projects = site.projects | sort: 'sort_key' %}
+                                        {% for project in sorted_projects %}
                                             {% if project.url != page.url %}
                                                 <div class="col col-6 col-md-3 p-4 d-flex justify-content-center">
                                                     <a href="{{project.url}}">

--- a/_projects/hafnium.md
+++ b/_projects/hafnium.md
@@ -35,5 +35,5 @@ top_text: |-
   Please subscribe to the project email list to to participate in development discussions.
   
   Hafnium and Secure-EL2 are topics also discussed in the TF-A Tech Forum.
-
+sort_key: 5
 ---

--- a/_projects/mbed-tls.md
+++ b/_projects/mbed-tls.md
@@ -32,4 +32,5 @@ top_text: |-
   Contribution guidelines can be found in the documentation.
 
   Please subscribe to the project email list to to participate in development discussions.
+sort_key: 4
 ---

--- a/_projects/op-tee.md
+++ b/_projects/op-tee.md
@@ -27,4 +27,5 @@ top_text: |-
   Contribution guidelines can be found in the documentation.
 
   Please subscribe to the project email list to to participate in development discussions.
+sort_key: 3
 ---

--- a/_projects/tf-a.md
+++ b/_projects/tf-a.md
@@ -43,4 +43,5 @@ top_text: |-
   Please subscribe to the project email list to to participate in development discussions.
 
   A bi-weekly [Technical Forum call](/meetings/tf-a-technical-forum/) is held to discuss technical subjects.
+sort_key: 1
 ---

--- a/_projects/tf-m.md
+++ b/_projects/tf-m.md
@@ -37,4 +37,5 @@ top_text: |-
   Please subscribe to the project email list to to participate in development discussions.
 
   A bi-weekly [Technical Forum call](/meetings/tf-m-technical-forum/) is held to discuss technical subjects.
+sort_key: 2
 ---


### PR DESCRIPTION
Add's the ability to supply a custom `sort_key` for each project. This `sort_key` is then used to order the projects on the home page and the "Other Projects" section.