### PR TITLE
remove phabricator links for TF-A / Hafnium

### DIFF
--- a/src/content/meetings/tf-a-technical-forum.md
+++ b/src/content/meetings/tf-a-technical-forum.md
@@ -7,7 +7,7 @@ image: ../../assets/images/blog/x15_demo_tf_crop_1500x1500.png
 
 ## TF-A Technical Forum
 
-This is an open forum conference call for anyone to participate and it is not restricted to TF members. It will operate under the guidance of the TF TSC. Invites and other traffic are via the TF-A mailing list. Attendees are welcome to propose agenda items. A [Scheduling Tracking Page](https://developer.trustedfirmware.org/w/tf_a/tf-a-tech-forum-scheduling/) shows possible future items and their current status.
+This is an open forum conference call for anyone to participate and it is not restricted to TF members. It will operate under the guidance of the TF TSC. Invites and other traffic are via the TF-A mailing list. Attendees are welcome to propose agenda items.
 
 To receive an invite, please join the TF-A mailing list. [Subscribe to the TF-A list](https://lists.trustedfirmware.org/mailman3/lists/tf-a.lists.trustedfirmware.org/) , or see the calendar links at the bottom of the page.
 

--- a/src/content/projects/hafnium.md
+++ b/src/content/projects/hafnium.md
@@ -26,8 +26,10 @@ links:
     text: Subscribe to the Hafnium mailing list
     url: https://lists.trustedfirmware.org/mailman3/lists/hafnium.lists.trustedfirmware.org/
 useful_links:
-  - text: Hafnium Project Dashboard
-    url: https://developer.trustedfirmware.org/project/21/item/view/67/
+  - text: Hafnium Github mirror
+    url: https://github.com/TF-Hafnium/hafnium
+  - text: Hafnium Issues list
+    url: https://github.com/TF-Hafnium/hafnium/issues
 top_text: |-
   **A reference Secure Partition Manager (SPM) for systems that implement the Armv8.4-A Secure-EL2 extension. It enables multiple, isolated Secure Partitions (SPs) to run at Secure-EL1.**
 

--- a/src/content/projects/tf-a-lts.md
+++ b/src/content/projects/tf-a-lts.md
@@ -27,15 +27,6 @@ links:
     text: Subscribe to the TF-A LTS mailing list
     button_style: bg-green-600 decoration-green-600
     url: https://lists.trustedfirmware.org/mailman3/lists/tfa-lts.lists.trustedfirmware.org/
-useful_links:
-  - text: TF-A LTS Dashboard
-    url: https://developer.trustedfirmware.org/dashboard/view/6/
-  - text: TF-A LTS Project page
-    url: https://developer.trustedfirmware.org/project/profile/1/
-  - text: TF-A LTS Tests Project page
-    url: https://developer.trustedfirmware.org/project/view/9/
-  - text: Wiki pages
-    url: https://developer.trustedfirmware.org/w/tf_a/
 top_text: |-
   **The Trusted Firmware-A LTS project provides ...**
 

--- a/src/content/projects/tf-a.md
+++ b/src/content/projects/tf-a.md
@@ -30,14 +30,12 @@ links:
     text: Subscribe to the TF-A mailing list
     url: https://lists.trustedfirmware.org/mailman3/lists/tf-a.lists.trustedfirmware.org/
 useful_links:
-  - text: TF-A Dashboard
-    url: https://developer.trustedfirmware.org/dashboard/view/6/
-  - text: TF-A Project page
-    url: https://developer.trustedfirmware.org/project/profile/1/
-  - text: TF-A Tests Project page
-    url: https://developer.trustedfirmware.org/project/view/9/
-  - text: Wiki pages
-    url: https://developer.trustedfirmware.org/w/tf_a/
+  - text: TF-A Github mirror
+    url: https://github.com/TrustedFirmware-A/trusted-firmware-a
+  - text: TF-A Issues list
+    url: https://github.com/TrustedFirmware-A/trusted-firmware-a/issues
+  - text: TF-A-tests project documentation
+    url: https://trustedfirmware-a-tests.readthedocs.io/en/latest/index.html
 top_text: |-
   **The Trusted Firmware-A project provides a reference implementation of secure world software for Armv7-A and Armv8-A class processors.**
 


### PR DESCRIPTION
Following deprecation of phabricator wikis, update links to new contents for TF-A and Hafnium projects.

There is no corresponding set of links for TF-A LTS as of yet, so remove all of them. This page will be adjusted later when this contents is available.