### PR TITLE
dashboard: rename main job and remove weekly

### DIFF
--- a/fetch_dashboard_data.py
+++ b/fetch_dashboard_data.py
@@ -15,11 +15,9 @@ logger = logging.getLogger(__name__)
 projects = {
     "TF-A": {
         "Daily": [
-            "https://ci.trustedfirmware.org/job/tf-a-main/",
+            "https://ci.trustedfirmware.org/job/tf-a-main-pipeline/",
         ],
-        "Weekly": [
-            "https://ci.trustedfirmware.org/job/tf-a-weekly/"
-        ],
+        "Weekly": [],
         "MISRA": [
             "https://ci.trustedfirmware.org/job/tf-a-eclair-delta/"
         ],


### PR DESCRIPTION
The tf-a-main job has been renamed to tf-a-main-pipeline and tf-a-weekly has been absorbed into the daily job and no longer exists.